### PR TITLE
Update with latest 4.x Releases

### DIFF
--- a/_deployment/checklist/student_4x/index.md
+++ b/_deployment/checklist/student_4x/index.md
@@ -16,15 +16,15 @@ Docker images are tagged with the same version as listed here.  The only project
 
 | Project | Version |
 | :------- | :------- |
-| Student &nbsp; | [4.0.4.RELEASE](https://github.com/SmarterApp/TDS_Student/releases/tag/4.0.4.RELEASE) |
+| Student &nbsp; | [4.0.6.RELEASE](https://github.com/SmarterApp/TDS_Student/releases/tag/4.0.6.RELEASE) |
 | Proctor &nbsp; | [4.1.0.RELEASE](https://github.com/SmarterApp/TDS_Proctor/releases/tag/4.1.0.RELEASE) |
 | Assessment Service &nbsp;| [4.0.0.RELEASE](https://github.com/SmarterApp/TDS_AssessmentService/releases/tag/4.0.0.RELEASE) |
 | Session Service &nbsp; | [3.1.3.RELEASE](https://github.com/SmarterApp/TDS_SessionService/releases/tag/3.1.3.RELEASE) |
 | Config Service &nbsp; | [4.1.0.RELEASE](https://github.com/SmarterApp/TDS_ConfigService/releases/tag/4.1.0.RELEASE) |
-| Exam Service &nbsp;| [4.1.1.RELEASE](https://github.com/SmarterApp/TDS_ExamService/releases/tag/4.1.1.RELEASE) |
+| Exam Service &nbsp;| [4.1.3.RELEASE](https://github.com/SmarterApp/TDS_ExamService/releases/tag/4.1.3.RELEASE) |
 | Student Service &nbsp;| [4.0.3.RELEASE](https://github.com/SmarterApp/TDS_StudentService/releases/tag/4.0.3.RELEASE) |
 | Content Service &nbsp;| [1.0.6.RELEASE](https://github.com/SmarterApp/TDS_ContentService/releases/tag/1.0.6.RELEASE) |
-| Exam Results Transmitter &nbsp;| [4.1.0.RELEASE](https://github.com/SmarterApp/TDS_ExamResultsTransmitter/releases/tag/4.1.0.RELEASE) |
+| Exam Results Transmitter &nbsp;| [4.1.1.RELEASE](https://github.com/SmarterApp/TDS_ExamResultsTransmitter/releases/tag/4.1.1.RELEASE) |
 | Equation Scoring Service &nbsp;| [3.1.1.RELEASE](https://github.com/SmarterApp/TDS_ItemScoring/releases/tag/3.1.1.RELEASE) |
 | Configuration Service &nbsp;| [3.1.1.RELEASE](https://github.com/SmarterApp/SS_ConfigurationService/releases/tag/3.1.1.RELEASE) |
 

--- a/_deployment/checklist/student_4x/index.md
+++ b/_deployment/checklist/student_4x/index.md
@@ -24,7 +24,7 @@ Docker images are tagged with the same version as listed here.  The only project
 | Exam Service &nbsp;| [4.1.1.RELEASE](https://github.com/SmarterApp/TDS_ExamService/releases/tag/4.1.1.RELEASE) |
 | Student Service &nbsp;| [4.0.3.RELEASE](https://github.com/SmarterApp/TDS_StudentService/releases/tag/4.0.3.RELEASE) |
 | Content Service &nbsp;| [1.0.6.RELEASE](https://github.com/SmarterApp/TDS_ContentService/releases/tag/1.0.6.RELEASE) |
-| Exam Results Transmitter &nbsp;| [4.0.1.RELEASE](https://github.com/SmarterApp/TDS_ExamResultsTransmitter/releases/tag/4.0.1.RELEASE) |
+| Exam Results Transmitter &nbsp;| [4.1.0.RELEASE](https://github.com/SmarterApp/TDS_ExamResultsTransmitter/releases/tag/4.1.0.RELEASE) |
 | Equation Scoring Service &nbsp;| [3.1.1.RELEASE](https://github.com/SmarterApp/TDS_ItemScoring/releases/tag/3.1.1.RELEASE) |
 | Configuration Service &nbsp;| [3.1.1.RELEASE](https://github.com/SmarterApp/SS_ConfigurationService/releases/tag/3.1.1.RELEASE) |
 


### PR DESCRIPTION
This PR updates the 4.x deployment documentation with the latest versions of the following components:

* Exam Microservice
* Exam Results Transmitter
* Student